### PR TITLE
Refactor input handling and add tests for credential management

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: ["*"]
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test -v -count=1 ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Build
         run: go build ./...

--- a/internal/erase.go
+++ b/internal/erase.go
@@ -1,12 +1,26 @@
 package internal
 
-// EraseCommand deletes a 1Password item based on the provided git input parameters.
-func EraseCommand() {
-	gitInputs := ReadLines()
+import (
+	"fmt"
+	"io"
+)
 
-	itemId := findItemId(gitInputs["protocol"], gitInputs["host"])
+// EraseCommand deletes a 1Password item based on the provided git input parameters.
+func EraseCommand(r io.Reader) error {
+	gitInputs, err := ReadLines(r)
+	if err != nil {
+		return fmt.Errorf("reading input: %w", err)
+	}
+
+	itemId, err := findItemId(gitInputs["protocol"], gitInputs["host"])
+	if err != nil {
+		return err
+	}
 	if itemId != nil {
 		// run "op delete item" command with the found item id
-		buildOpItemCommand("delete", *itemId).Run()
+		if err := Runner.DeleteItem(*itemId); err != nil {
+			return fmt.Errorf("op item delete failed: %w", err)
+		}
 	}
+	return nil
 }

--- a/internal/erase_test.go
+++ b/internal/erase_test.go
@@ -1,0 +1,111 @@
+package internal
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestEraseCommand(t *testing.T) {
+	t.Run("item found and deleted", func(t *testing.T) {
+		m := &mockRunner{
+			listItemsResult: &OpItemListResult{
+				{Id: "item-1", URLs: []struct {
+					Href string `json:"href,omitempty"`
+				}{{Href: "https://github.com"}}},
+			},
+		}
+		setupTest(t, m)
+
+		input := "protocol=https\nhost=github.com\n\n"
+		err := EraseCommand(strings.NewReader(input))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(m.deleteItemCalledWith) != 1 {
+			t.Fatalf("DeleteItem called %d times, want 1", len(m.deleteItemCalledWith))
+		}
+		if m.deleteItemCalledWith[0] != "item-1" {
+			t.Errorf("DeleteItem called with %q, want 'item-1'", m.deleteItemCalledWith[0])
+		}
+	})
+
+	t.Run("item not found", func(t *testing.T) {
+		m := &mockRunner{
+			listItemsResult: &OpItemListResult{},
+		}
+		setupTest(t, m)
+
+		input := "protocol=https\nhost=github.com\n\n"
+		err := EraseCommand(strings.NewReader(input))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(m.deleteItemCalledWith) != 0 {
+			t.Errorf("DeleteItem called %d times, want 0", len(m.deleteItemCalledWith))
+		}
+	})
+
+	t.Run("delete error", func(t *testing.T) {
+		m := &mockRunner{
+			listItemsResult: &OpItemListResult{
+				{Id: "item-1", URLs: []struct {
+					Href string `json:"href,omitempty"`
+				}{{Href: "https://github.com"}}},
+			},
+			deleteItemErr: fmt.Errorf("permission denied"),
+		}
+		setupTest(t, m)
+
+		input := "protocol=https\nhost=github.com\n\n"
+		err := EraseCommand(strings.NewReader(input))
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "op item delete failed") {
+			t.Errorf("error = %q, want to contain 'op item delete failed'", err)
+		}
+	})
+
+	t.Run("list items error", func(t *testing.T) {
+		m := &mockRunner{
+			listItemsErr: fmt.Errorf("op not found"),
+		}
+		setupTest(t, m)
+
+		input := "protocol=https\nhost=github.com\n\n"
+		err := EraseCommand(strings.NewReader(input))
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("invalid input", func(t *testing.T) {
+		m := &mockRunner{}
+		setupTest(t, m)
+
+		input := "malformed\n"
+		err := EraseCommand(strings.NewReader(input))
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("with explicit ItemID", func(t *testing.T) {
+		m := &mockRunner{}
+		setupTest(t, m)
+		ItemID = "explicit-id"
+
+		input := "protocol=https\nhost=github.com\n\n"
+		err := EraseCommand(strings.NewReader(input))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(m.deleteItemCalledWith) != 1 {
+			t.Fatalf("DeleteItem called %d times, want 1", len(m.deleteItemCalledWith))
+		}
+		if m.deleteItemCalledWith[0] != "explicit-id" {
+			t.Errorf("DeleteItem called with %q, want 'explicit-id'", m.deleteItemCalledWith[0])
+		}
+	})
+}

--- a/internal/get.go
+++ b/internal/get.go
@@ -1,40 +1,49 @@
 package internal
 
 import (
+	"errors"
 	"fmt"
-	"log"
-	"os"
+	"io"
 )
 
-// GetCommand retrieves and prints the username and password from a 1Password item based on git input parameters.
-func GetCommand() {
+// ErrNotFound indicates that the credential was not found in 1Password.
+var ErrNotFound = errors.New("credential not found")
+
+// GetCommand retrieves and prints the username and password from a 1Password item
+// based on git input parameters. It reads input from r and writes credentials to w.
+func GetCommand(r io.Reader, w io.Writer) error {
 	// git sends the input to stdin
-	gitInputs := ReadLines()
+	gitInputs, err := ReadLines(r)
+	if err != nil {
+		return fmt.Errorf("reading input: %w", err)
+	}
 
 	// check if the host field is present in the input
 	if _, ok := gitInputs["host"]; !ok {
-		log.Fatalf("host is missing in the input")
+		return fmt.Errorf("host is missing in the input")
 	}
 
-	itemId := findItemId(gitInputs["protocol"], gitInputs["host"])
-	// if the host is not found, we exit with status code 1 to indicate that the host is not found
-	// we don't want to print anything to stdout in this case as it is not a real error
+	itemId, err := findItemId(gitInputs["protocol"], gitInputs["host"])
+	if err != nil {
+		return err
+	}
+	// if the host is not found, we return ErrNotFound
 	if itemId == nil {
-		os.Exit(1)
+		return ErrNotFound
 	}
 
 	// fetch the item from 1password using the id
-	opItem, err := opGetItem(*itemId)
+	opItem, err := Runner.GetItem(*itemId)
 	if err != nil {
-		// we bail out if we can't get the item we just listed above - something is wrong and should be reported
-		log.Fatalf("op item get failed with %s", err)
+		return fmt.Errorf("op item get failed: %w", err)
 	}
 
 	// feed the username and password to git
 	username := opItem.GetField(UsernameField)
 	password := opItem.GetField(PasswordField)
 	if username == "" || password == "" {
-		log.Fatalf("username or password is empty, is the item named correctly?")
+		return fmt.Errorf("username or password is empty, is the item named correctly?")
 	}
-	fmt.Printf("username=%s\npassword=%s\n\n", username, password)
+	fmt.Fprintf(w, "username=%s\npassword=%s\n\n", username, password)
+	return nil
 }

--- a/internal/get_test.go
+++ b/internal/get_test.go
@@ -1,0 +1,216 @@
+package internal
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestGetCommand(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		m := &mockRunner{
+			listItemsResult: &OpItemListResult{
+				{Id: "item-1", URLs: []struct {
+					Href string `json:"href,omitempty"`
+				}{{Href: "https://github.com"}}},
+			},
+			getItemResult: OpItem{
+				{Label: "username", Value: "alice"},
+				{Label: "password", Value: "secret"},
+			},
+		}
+		setupTest(t, m)
+
+		input := "protocol=https\nhost=github.com\n\n"
+		var buf bytes.Buffer
+		err := GetCommand(strings.NewReader(input), &buf)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		expected := "username=alice\npassword=secret\n\n"
+		if buf.String() != expected {
+			t.Errorf("output = %q, want %q", buf.String(), expected)
+		}
+	})
+
+	t.Run("with explicit ItemID", func(t *testing.T) {
+		m := &mockRunner{
+			getItemResult: OpItem{
+				{Label: "username", Value: "bob"},
+				{Label: "password", Value: "pass123"},
+			},
+		}
+		setupTest(t, m)
+		ItemID = "explicit-id"
+
+		input := "protocol=https\nhost=github.com\n\n"
+		var buf bytes.Buffer
+		err := GetCommand(strings.NewReader(input), &buf)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(m.getItemCalledWith) != 1 || m.getItemCalledWith[0] != "explicit-id" {
+			t.Errorf("GetItem called with %v, want [explicit-id]", m.getItemCalledWith)
+		}
+	})
+
+	t.Run("missing host", func(t *testing.T) {
+		m := &mockRunner{}
+		setupTest(t, m)
+
+		input := "protocol=https\n\n"
+		var buf bytes.Buffer
+		err := GetCommand(strings.NewReader(input), &buf)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "host is missing") {
+			t.Errorf("error = %q, want to contain 'host is missing'", err)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		m := &mockRunner{
+			listItemsResult: &OpItemListResult{},
+		}
+		setupTest(t, m)
+
+		input := "protocol=https\nhost=github.com\n\n"
+		var buf bytes.Buffer
+		err := GetCommand(strings.NewReader(input), &buf)
+		if !errors.Is(err, ErrNotFound) {
+			t.Errorf("error = %v, want ErrNotFound", err)
+		}
+	})
+
+	t.Run("opGetItem error", func(t *testing.T) {
+		m := &mockRunner{
+			listItemsResult: &OpItemListResult{
+				{Id: "item-1", URLs: []struct {
+					Href string `json:"href,omitempty"`
+				}{{Href: "https://github.com"}}},
+			},
+			getItemErr: fmt.Errorf("connection timeout"),
+		}
+		setupTest(t, m)
+
+		input := "protocol=https\nhost=github.com\n\n"
+		var buf bytes.Buffer
+		err := GetCommand(strings.NewReader(input), &buf)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "connection timeout") {
+			t.Errorf("error = %q, want to contain 'connection timeout'", err)
+		}
+	})
+
+	t.Run("empty username", func(t *testing.T) {
+		m := &mockRunner{
+			listItemsResult: &OpItemListResult{
+				{Id: "item-1", URLs: []struct {
+					Href string `json:"href,omitempty"`
+				}{{Href: "https://github.com"}}},
+			},
+			getItemResult: OpItem{
+				{Label: "username", Value: ""},
+				{Label: "password", Value: "secret"},
+			},
+		}
+		setupTest(t, m)
+
+		input := "protocol=https\nhost=github.com\n\n"
+		var buf bytes.Buffer
+		err := GetCommand(strings.NewReader(input), &buf)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "username or password is empty") {
+			t.Errorf("error = %q, want to contain 'username or password is empty'", err)
+		}
+	})
+
+	t.Run("empty password", func(t *testing.T) {
+		m := &mockRunner{
+			listItemsResult: &OpItemListResult{
+				{Id: "item-1", URLs: []struct {
+					Href string `json:"href,omitempty"`
+				}{{Href: "https://github.com"}}},
+			},
+			getItemResult: OpItem{
+				{Label: "username", Value: "alice"},
+				{Label: "password", Value: ""},
+			},
+		}
+		setupTest(t, m)
+
+		input := "protocol=https\nhost=github.com\n\n"
+		var buf bytes.Buffer
+		err := GetCommand(strings.NewReader(input), &buf)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "username or password is empty") {
+			t.Errorf("error = %q, want to contain 'username or password is empty'", err)
+		}
+	})
+
+	t.Run("list items error", func(t *testing.T) {
+		m := &mockRunner{
+			listItemsErr: fmt.Errorf("op not found"),
+		}
+		setupTest(t, m)
+
+		input := "protocol=https\nhost=github.com\n\n"
+		var buf bytes.Buffer
+		err := GetCommand(strings.NewReader(input), &buf)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("invalid input", func(t *testing.T) {
+		m := &mockRunner{}
+		setupTest(t, m)
+
+		input := "malformed-line\n"
+		var buf bytes.Buffer
+		err := GetCommand(strings.NewReader(input), &buf)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "reading input") {
+			t.Errorf("error = %q, want to contain 'reading input'", err)
+		}
+	})
+
+	t.Run("custom field names", func(t *testing.T) {
+		m := &mockRunner{
+			listItemsResult: &OpItemListResult{
+				{Id: "item-1", URLs: []struct {
+					Href string `json:"href,omitempty"`
+				}{{Href: "https://github.com"}}},
+			},
+			getItemResult: OpItem{
+				{Label: "email", Value: "alice@example.com"},
+				{Label: "token", Value: "ghp_abc123"},
+			},
+		}
+		setupTest(t, m)
+		UsernameField = "email"
+		PasswordField = "token"
+
+		input := "protocol=https\nhost=github.com\n\n"
+		var buf bytes.Buffer
+		err := GetCommand(strings.NewReader(input), &buf)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		expected := "username=alice@example.com\npassword=ghp_abc123\n\n"
+		if buf.String() != expected {
+			t.Errorf("output = %q, want %q", buf.String(), expected)
+		}
+	})
+}

--- a/internal/inputs.go
+++ b/internal/inputs.go
@@ -2,43 +2,45 @@ package internal
 
 import (
 	"bufio"
+	"fmt"
 	"io"
-	"log"
-	"os"
 	"strings"
 )
 
-// ReadLines reads the input from stdin and returns a map of key value pairs
-func ReadLines() (inputs map[string]string) {
-	inputs = make(map[string]string)
-	// create stdin reader
-	r := bufio.NewReader(os.Stdin)
-	w := bufio.NewWriter(os.Stdout)
-	defer w.Flush()
+// ReadLines reads the input from a reader and returns a map of key value pairs.
+// Input follows the git credential helper protocol: key=value lines terminated by
+// a blank line or EOF.
+func ReadLines(r io.Reader) (map[string]string, error) {
+	inputs := make(map[string]string)
+	br := bufio.NewReader(r)
 
 	for {
-		// line by line read from stdin
-		line, err := r.ReadString('\n')
+		line, err := br.ReadString('\n')
 		if err == io.EOF {
+			// Process any remaining content before EOF
+			line = strings.TrimRight(line, "\r\n")
+			if line != "" {
+				key, val, ok := strings.Cut(line, "=")
+				if !ok {
+					return nil, fmt.Errorf("invalid input: %s", line)
+				}
+				inputs[strings.TrimSpace(key)] = strings.TrimSpace(val)
+			}
 			break
 		}
 		if err != nil {
-			log.Fatal(err)
+			return nil, err
 		}
 		line = strings.TrimRight(line, "\r\n")
 		if line == "" {
 			break
 		}
 
-		// split the line by the first '=' and create a key value pair
 		key, val, ok := strings.Cut(line, "=")
 		if !ok {
-			log.Fatalf("Invalid input: %s", line)
+			return nil, fmt.Errorf("invalid input: %s", line)
 		}
-		key = strings.TrimSpace(key)
-		val = strings.TrimSpace(val)
-
-		inputs[key] = val
+		inputs[strings.TrimSpace(key)] = strings.TrimSpace(val)
 	}
-	return inputs
+	return inputs, nil
 }

--- a/internal/inputs_test.go
+++ b/internal/inputs_test.go
@@ -1,0 +1,122 @@
+package internal
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestReadLines(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			name:  "valid input with blank line terminator",
+			input: "protocol=https\nhost=github.com\n\n",
+			want: map[string]string{
+				"protocol": "https",
+				"host":     "github.com",
+			},
+		},
+		{
+			name:  "valid input EOF terminated",
+			input: "protocol=https\nhost=github.com",
+			want: map[string]string{
+				"protocol": "https",
+				"host":     "github.com",
+			},
+		},
+		{
+			name:  "empty input",
+			input: "",
+			want:  map[string]string{},
+		},
+		{
+			name:  "single blank line",
+			input: "\n",
+			want:  map[string]string{},
+		},
+		{
+			name:    "malformed line no equals",
+			input:   "invalid-line\n",
+			wantErr: true,
+		},
+		{
+			name:    "malformed line no equals EOF",
+			input:   "invalid-line",
+			wantErr: true,
+		},
+		{
+			name:  "whitespace trimming",
+			input: " protocol = https \n host = github.com \n\n",
+			want: map[string]string{
+				"protocol": "https",
+				"host":     "github.com",
+			},
+		},
+		{
+			name:  "value with equals sign",
+			input: "password=my=password\n\n",
+			want: map[string]string{
+				"password": "my=password",
+			},
+		},
+		{
+			name:  "CRLF line endings",
+			input: "protocol=https\r\nhost=github.com\r\n\r\n",
+			want: map[string]string{
+				"protocol": "https",
+				"host":     "github.com",
+			},
+		},
+		{
+			name:  "full credential block",
+			input: "protocol=https\nhost=github.com\nusername=alice\npassword=secret\n\n",
+			want: map[string]string{
+				"protocol": "https",
+				"host":     "github.com",
+				"username": "alice",
+				"password": "secret",
+			},
+		},
+		{
+			name:  "single key-value EOF",
+			input: "host=example.com",
+			want: map[string]string{
+				"host": "example.com",
+			},
+		},
+		{
+			name:  "empty value",
+			input: "host=\n\n",
+			want: map[string]string{
+				"host": "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ReadLines(strings.NewReader(tt.input))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d entries, want %d: %v", len(got), len(tt.want), got)
+			}
+			for k, v := range tt.want {
+				if got[k] != v {
+					t.Errorf("got[%q] = %q, want %q", k, got[k], v)
+				}
+			}
+		})
+	}
+}

--- a/internal/mock_test.go
+++ b/internal/mock_test.go
@@ -1,0 +1,91 @@
+package internal
+
+import "testing"
+
+// mockRunner implements OpRunner for testing.
+type mockRunner struct {
+	listItemsResult  *OpItemListResult
+	listItemsErr     error
+	getItemResult    OpItem
+	getItemErr       error
+	createItemResult []byte
+	createItemErr    error
+	editItemResult   []byte
+	editItemErr      error
+	deleteItemErr    error
+
+	getItemCalledWith    []string
+	createItemCalledWith [][]string
+	editItemCalledWith   [][]string
+	deleteItemCalledWith []string
+}
+
+func (m *mockRunner) ListItems() (*OpItemListResult, error) {
+	return m.listItemsResult, m.listItemsErr
+}
+
+func (m *mockRunner) GetItem(id string) (OpItem, error) {
+	m.getItemCalledWith = append(m.getItemCalledWith, id)
+	return m.getItemResult, m.getItemErr
+}
+
+func (m *mockRunner) CreateItem(args ...string) ([]byte, error) {
+	m.createItemCalledWith = append(m.createItemCalledWith, args)
+	return m.createItemResult, m.createItemErr
+}
+
+func (m *mockRunner) EditItem(args ...string) ([]byte, error) {
+	m.editItemCalledWith = append(m.editItemCalledWith, args)
+	return m.editItemResult, m.editItemErr
+}
+
+func (m *mockRunner) DeleteItem(id string) error {
+	m.deleteItemCalledWith = append(m.deleteItemCalledWith, id)
+	return m.deleteItemErr
+}
+
+// setupTest configures global state for testing and restores it on cleanup.
+func setupTest(t *testing.T, m *mockRunner) {
+	t.Helper()
+
+	origRunner := Runner
+	origAccount := Account
+	origVault := Vault
+	origCategory := Category
+	origPrefix := Prefix
+	origUsernameField := UsernameField
+	origPasswordField := PasswordField
+	origAllowErase := AllowErase
+	origReadOnly := ReadOnly
+	origOpPath := OpPath
+	origItemID := ItemID
+	origOpItemFlags := OpItemFlags
+
+	Runner = m
+	Account = ""
+	Vault = ""
+	Category = "Login"
+	Prefix = ""
+	UsernameField = "username"
+	PasswordField = "password"
+	AllowErase = false
+	ReadOnly = false
+	OpPath = ""
+	ItemID = ""
+	OpItemFlags = nil
+
+	t.Cleanup(func() {
+		Runner = origRunner
+		Account = origAccount
+		Vault = origVault
+		Category = origCategory
+		Prefix = origPrefix
+		UsernameField = origUsernameField
+		PasswordField = origPasswordField
+		AllowErase = origAllowErase
+		ReadOnly = origReadOnly
+		OpPath = origOpPath
+		ItemID = origItemID
+		OpItemFlags = origOpItemFlags
+	})
+}

--- a/internal/op.go
+++ b/internal/op.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"os/exec"
 	"runtime"
 )
@@ -25,6 +24,22 @@ var (
 const (
 	TagMarker = "git-credential-1password"
 )
+
+// OpRunner is the interface for interacting with the 1Password CLI.
+type OpRunner interface {
+	ListItems() (*OpItemListResult, error)
+	GetItem(id string) (OpItem, error)
+	CreateItem(args ...string) ([]byte, error)
+	EditItem(args ...string) ([]byte, error)
+	DeleteItem(id string) error
+}
+
+// Runner is the package-level OpRunner used by command functions.
+// It defaults to ExecOpRunner which calls the real op CLI.
+var Runner OpRunner = &ExecOpRunner{}
+
+// ExecOpRunner implements OpRunner by executing the op CLI.
+type ExecOpRunner struct{}
 
 // OpItemField is a field in the output of "op item get --format json" command
 // we are only interested in key value pairs from fields as label and value
@@ -94,57 +109,72 @@ func buildOpItemCommand(subcommand string, args ...string) *exec.Cmd {
 	return exec.Command(opCommand(), cmdArgs...)
 }
 
-// opListItems runs "op list items --format json" command to get all items with their ids
-func opListItems() (*OpItemListResult, error) {
+// ListItems runs "op item list --format json" command to get all items with their ids.
+func (e *ExecOpRunner) ListItems() (*OpItemListResult, error) {
 	cmd := buildOpItemCommand("list", "--categories", Category, "--format", "json", "--tags", TagMarker)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("opListItems failed with %s\n%s", err, output)
+		return nil, fmt.Errorf("op item list failed: %s\n%s", err, output)
 	}
 
 	var result OpItemListResult
 	if err = json.Unmarshal(output, &result); err != nil {
-		return nil, fmt.Errorf("json.Unmarshal() failed with %s", err)
+		return nil, fmt.Errorf("json.Unmarshal() failed: %s", err)
 	}
 
 	return &result, nil
 }
 
-// opGetItem runs "op item get --format json" command with the given name
-func opGetItem(n string) (OpItem, error) {
-	// --fields username,password limits the output to only username and password
+// GetItem runs "op item get --format json" command with the given id.
+func (e *ExecOpRunner) GetItem(id string) (OpItem, error) {
 	fields := fmt.Sprintf("%s,%s", UsernameField, PasswordField)
-	opItemGet := buildOpItemCommand("get", "--format", "json", "--reveal", "--fields", fields, n)
-	opItemRaw, err := opItemGet.CombinedOutput()
+	cmd := buildOpItemCommand("get", "--format", "json", "--reveal", "--fields", fields, id)
+	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("opItemGet failed with %s\n%s", err, opItemRaw)
+		return nil, fmt.Errorf("op item get failed: %s\n%s", err, output)
 	}
 
-	// marshal the raw output to OpItem struct
 	var opItem OpItem
-	if err = json.Unmarshal(opItemRaw, &opItem); err != nil {
-		return nil, fmt.Errorf("json.Unmarshal() failed with %s", err)
+	if err = json.Unmarshal(output, &opItem); err != nil {
+		return nil, fmt.Errorf("json.Unmarshal() failed: %s", err)
 	}
 	return opItem, nil
 }
 
-// findItemId finds the item id for a given host
-func findItemId(protocol string, host string) *string {
+// CreateItem runs "op item create" command.
+func (e *ExecOpRunner) CreateItem(args ...string) ([]byte, error) {
+	cmd := buildOpItemCommand("create", args...)
+	return cmd.CombinedOutput()
+}
+
+// EditItem runs "op item edit" command.
+func (e *ExecOpRunner) EditItem(args ...string) ([]byte, error) {
+	cmd := buildOpItemCommand("edit", args...)
+	return cmd.CombinedOutput()
+}
+
+// DeleteItem runs "op item delete" command.
+func (e *ExecOpRunner) DeleteItem(id string) error {
+	return buildOpItemCommand("delete", id).Run()
+}
+
+// findItemId finds the item id for a given host.
+func findItemId(protocol string, host string) (*string, error) {
 	// If an explicit item ID was provided via --id, use it directly
 	// and skip the list+filter lookup entirely.
 	if ItemID != "" {
-		return &ItemID
+		return &ItemID, nil
 	}
 
-	itemList, err := opListItems()
+	itemList, err := Runner.ListItems()
 	if err != nil {
-		log.Fatalf("op item list failed with %s", err)
+		return nil, fmt.Errorf("op item list failed: %w", err)
 	}
 
 	item := itemList.FindByURL(protocol + "://" + host)
 	if item == nil {
-		return nil
+		return nil, nil
 	}
 
-	return &item.Id
+	return &item.Id, nil
 }

--- a/internal/op_test.go
+++ b/internal/op_test.go
@@ -1,0 +1,349 @@
+package internal
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+)
+
+func TestGetField(t *testing.T) {
+	tests := []struct {
+		name     string
+		item     OpItem
+		label    string
+		expected string
+	}{
+		{
+			name: "field exists",
+			item: OpItem{
+				{Label: "username", Value: "alice"},
+				{Label: "password", Value: "secret"},
+			},
+			label:    "username",
+			expected: "alice",
+		},
+		{
+			name: "field missing",
+			item: OpItem{
+				{Label: "username", Value: "alice"},
+			},
+			label:    "password",
+			expected: "",
+		},
+		{
+			name:     "empty item",
+			item:     OpItem{},
+			label:    "username",
+			expected: "",
+		},
+		{
+			name: "duplicate labels returns first",
+			item: OpItem{
+				{Label: "username", Value: "first"},
+				{Label: "username", Value: "second"},
+			},
+			label:    "username",
+			expected: "first",
+		},
+		{
+			name: "empty label matches empty",
+			item: OpItem{
+				{Label: "", Value: "val"},
+			},
+			label:    "",
+			expected: "val",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.item.GetField(tt.label)
+			if got != tt.expected {
+				t.Errorf("GetField(%q) = %q, want %q", tt.label, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFindByURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		result  OpItemListResult
+		url     string
+		wantID  string
+		wantNil bool
+	}{
+		{
+			name: "URL match",
+			result: OpItemListResult{
+				{Id: "abc123", URLs: []struct {
+					Href string `json:"href,omitempty"`
+				}{{Href: "https://github.com"}}},
+			},
+			url:    "https://github.com",
+			wantID: "abc123",
+		},
+		{
+			name: "no match",
+			result: OpItemListResult{
+				{Id: "abc123", URLs: []struct {
+					Href string `json:"href,omitempty"`
+				}{{Href: "https://github.com"}}},
+			},
+			url:     "https://gitlab.com",
+			wantNil: true,
+		},
+		{
+			name:    "empty list",
+			result:  OpItemListResult{},
+			url:     "https://github.com",
+			wantNil: true,
+		},
+		{
+			name: "multiple URLs per item",
+			result: OpItemListResult{
+				{Id: "abc123", URLs: []struct {
+					Href string `json:"href,omitempty"`
+				}{
+					{Href: "https://github.com"},
+					{Href: "https://api.github.com"},
+				}},
+			},
+			url:    "https://api.github.com",
+			wantID: "abc123",
+		},
+		{
+			name: "multiple items first match wins",
+			result: OpItemListResult{
+				{Id: "first", URLs: []struct {
+					Href string `json:"href,omitempty"`
+				}{{Href: "https://github.com"}}},
+				{Id: "second", URLs: []struct {
+					Href string `json:"href,omitempty"`
+				}{{Href: "https://github.com"}}},
+			},
+			url:    "https://github.com",
+			wantID: "first",
+		},
+		{
+			name: "item with no URLs",
+			result: OpItemListResult{
+				{Id: "abc123", URLs: nil},
+			},
+			url:     "https://github.com",
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.result.FindByURL(tt.url)
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("FindByURL(%q) = %+v, want nil", tt.url, got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("FindByURL(%q) = nil, want id=%q", tt.url, tt.wantID)
+			}
+			if got.Id != tt.wantID {
+				t.Errorf("FindByURL(%q).Id = %q, want %q", tt.url, got.Id, tt.wantID)
+			}
+		})
+	}
+}
+
+func TestItemName(t *testing.T) {
+	tests := []struct {
+		name     string
+		prefix   string
+		host     string
+		expected string
+	}{
+		{"no prefix", "", "github.com", "github.com"},
+		{"with prefix", "git-", "github.com", "git-github.com"},
+		{"empty host", "prefix-", "", "prefix-"},
+		{"both empty", "", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origPrefix := Prefix
+			Prefix = tt.prefix
+			defer func() { Prefix = origPrefix }()
+
+			got := itemName(tt.host)
+			if got != tt.expected {
+				t.Errorf("itemName(%q) = %q, want %q", tt.host, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestOpCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		opPath   string
+		expected string
+	}{
+		{"custom path", "/usr/local/bin/op", "/usr/local/bin/op"},
+	}
+
+	// Add OS-specific test
+	if runtime.GOOS == "windows" {
+		tests = append(tests, struct {
+			name     string
+			opPath   string
+			expected string
+		}{"default on windows", "", "op.exe"})
+	} else {
+		tests = append(tests, struct {
+			name     string
+			opPath   string
+			expected string
+		}{"default on non-windows", "", "op"})
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origOpPath := OpPath
+			OpPath = tt.opPath
+			defer func() { OpPath = origOpPath }()
+
+			got := opCommand()
+			if got != tt.expected {
+				t.Errorf("opCommand() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBuildOpItemCommand(t *testing.T) {
+	origOpPath := OpPath
+	origFlags := OpItemFlags
+	defer func() {
+		OpPath = origOpPath
+		OpItemFlags = origFlags
+	}()
+
+	OpPath = "/usr/bin/op"
+	OpItemFlags = nil
+
+	t.Run("simple subcommand", func(t *testing.T) {
+		cmd := buildOpItemCommand("list", "--format", "json")
+		expected := []string{"/usr/bin/op", "item", "list", "--format", "json"}
+		if len(cmd.Args) != len(expected) {
+			t.Fatalf("Args length = %d, want %d: %v", len(cmd.Args), len(expected), cmd.Args)
+		}
+		for i, arg := range expected {
+			if cmd.Args[i] != arg {
+				t.Errorf("Args[%d] = %q, want %q", i, cmd.Args[i], arg)
+			}
+		}
+	})
+
+	t.Run("with OpItemFlags", func(t *testing.T) {
+		OpItemFlags = []string{"--account", "myaccount", "--vault", "myvault"}
+		cmd := buildOpItemCommand("get", "item123")
+		expected := []string{"/usr/bin/op", "item", "get", "--account", "myaccount", "--vault", "myvault", "item123"}
+		if len(cmd.Args) != len(expected) {
+			t.Fatalf("Args length = %d, want %d: %v", len(cmd.Args), len(expected), cmd.Args)
+		}
+		for i, arg := range expected {
+			if cmd.Args[i] != arg {
+				t.Errorf("Args[%d] = %q, want %q", i, cmd.Args[i], arg)
+			}
+		}
+	})
+
+	t.Run("no extra args", func(t *testing.T) {
+		OpItemFlags = nil
+		cmd := buildOpItemCommand("list")
+		expected := []string{"/usr/bin/op", "item", "list"}
+		if len(cmd.Args) != len(expected) {
+			t.Fatalf("Args length = %d, want %d: %v", len(cmd.Args), len(expected), cmd.Args)
+		}
+	})
+}
+
+func TestFindItemId(t *testing.T) {
+	t.Run("with explicit ItemID", func(t *testing.T) {
+		m := &mockRunner{}
+		setupTest(t, m)
+		ItemID = "explicit-id"
+
+		id, err := findItemId("https", "github.com")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if id == nil || *id != "explicit-id" {
+			t.Errorf("findItemId() = %v, want 'explicit-id'", id)
+		}
+	})
+
+	t.Run("found via list", func(t *testing.T) {
+		m := &mockRunner{
+			listItemsResult: &OpItemListResult{
+				{Id: "found-id", URLs: []struct {
+					Href string `json:"href,omitempty"`
+				}{{Href: "https://github.com"}}},
+			},
+		}
+		setupTest(t, m)
+
+		id, err := findItemId("https", "github.com")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if id == nil || *id != "found-id" {
+			t.Errorf("findItemId() = %v, want 'found-id'", id)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		m := &mockRunner{
+			listItemsResult: &OpItemListResult{
+				{Id: "other-id", URLs: []struct {
+					Href string `json:"href,omitempty"`
+				}{{Href: "https://gitlab.com"}}},
+			},
+		}
+		setupTest(t, m)
+
+		id, err := findItemId("https", "github.com")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if id != nil {
+			t.Errorf("findItemId() = %v, want nil", *id)
+		}
+	})
+
+	t.Run("list error", func(t *testing.T) {
+		m := &mockRunner{
+			listItemsErr: fmt.Errorf("connection refused"),
+		}
+		setupTest(t, m)
+
+		_, err := findItemId("https", "github.com")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("empty list", func(t *testing.T) {
+		m := &mockRunner{
+			listItemsResult: &OpItemListResult{},
+		}
+		setupTest(t, m)
+
+		id, err := findItemId("https", "github.com")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if id != nil {
+			t.Errorf("findItemId() = %v, want nil", *id)
+		}
+	})
+}

--- a/internal/store.go
+++ b/internal/store.go
@@ -2,28 +2,40 @@ package internal
 
 import (
 	"fmt"
-	"log"
+	"io"
 )
 
-func StoreCommand() {
-	gitInputs := ReadLines()
+// StoreCommand stores or updates credentials in 1Password.
+func StoreCommand(r io.Reader) error {
+	gitInputs, err := ReadLines(r)
+	if err != nil {
+		return fmt.Errorf("reading input: %w", err)
+	}
 
-	itemId := findItemId(gitInputs["protocol"], gitInputs["host"])
+	itemId, err := findItemId(gitInputs["protocol"], gitInputs["host"])
+	if err != nil {
+		return err
+	}
 	if itemId == nil {
 		// run "op item create" command with the host value
 		userStr := fmt.Sprintf("%s=%s", UsernameField, gitInputs["username"])
 		pwStr := fmt.Sprintf("%s=%s", PasswordField, gitInputs["password"])
-		cmd := buildOpItemCommand("create", "--category="+Category, "--tags="+TagMarker, "--title="+itemName(gitInputs["host"]), "--url="+gitInputs["protocol"]+"://"+gitInputs["host"], userStr, pwStr)
-		output, err := cmd.CombinedOutput()
+		_, err := Runner.CreateItem(
+			"--category="+Category,
+			"--tags="+TagMarker,
+			"--title="+itemName(gitInputs["host"]),
+			"--url="+gitInputs["protocol"]+"://"+gitInputs["host"],
+			userStr, pwStr,
+		)
 		if err != nil {
-			log.Fatalf("op item create failed with %s %s", err, output)
+			return fmt.Errorf("op item create failed: %w", err)
 		}
-		return
+		return nil
 	}
 
-	item, err := opGetItem(*itemId)
+	item, err := Runner.GetItem(*itemId)
 	if err != nil {
-		log.Fatalf("op item get failed with %s", err)
+		return fmt.Errorf("op item get failed: %w", err)
 	}
 
 	// only update the item if the username or password has changed
@@ -36,10 +48,10 @@ func StoreCommand() {
 		//   we don't set --url here as we use it to find the item, and therefore it must be correct already
 		userStr := fmt.Sprintf("%s=%s", UsernameField, gitInputs["username"])
 		pwStr := fmt.Sprintf("%s=%s", PasswordField, gitInputs["password"])
-		cmd := buildOpItemCommand("edit", *itemId, userStr, pwStr)
-		output, err := cmd.CombinedOutput()
+		_, err := Runner.EditItem(*itemId, userStr, pwStr)
 		if err != nil {
-			log.Fatalf("op item edit failed with %s %s", err, output)
+			return fmt.Errorf("op item edit failed: %w", err)
 		}
 	}
+	return nil
 }

--- a/internal/store_test.go
+++ b/internal/store_test.go
@@ -1,0 +1,271 @@
+package internal
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestStoreCommand(t *testing.T) {
+	t.Run("create new item", func(t *testing.T) {
+		m := &mockRunner{
+			listItemsResult: &OpItemListResult{},
+		}
+		setupTest(t, m)
+
+		input := "protocol=https\nhost=github.com\nusername=alice\npassword=secret\n\n"
+		err := StoreCommand(strings.NewReader(input))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(m.createItemCalledWith) != 1 {
+			t.Fatalf("CreateItem called %d times, want 1", len(m.createItemCalledWith))
+		}
+		args := m.createItemCalledWith[0]
+		// Verify key arguments are present
+		found := map[string]bool{}
+		for _, arg := range args {
+			if strings.HasPrefix(arg, "--category=") {
+				found["category"] = true
+			}
+			if strings.HasPrefix(arg, "--tags=") {
+				found["tags"] = true
+				if arg != "--tags="+TagMarker {
+					t.Errorf("tags arg = %q, want --tags=%s", arg, TagMarker)
+				}
+			}
+			if strings.HasPrefix(arg, "--title=") {
+				found["title"] = true
+			}
+			if strings.HasPrefix(arg, "--url=") {
+				found["url"] = true
+				if arg != "--url=https://github.com" {
+					t.Errorf("url arg = %q, want --url=https://github.com", arg)
+				}
+			}
+			if arg == "username=alice" {
+				found["username"] = true
+			}
+			if arg == "password=secret" {
+				found["password"] = true
+			}
+		}
+		for _, key := range []string{"category", "tags", "title", "url", "username", "password"} {
+			if !found[key] {
+				t.Errorf("missing %s in CreateItem args: %v", key, args)
+			}
+		}
+	})
+
+	t.Run("create error", func(t *testing.T) {
+		m := &mockRunner{
+			listItemsResult: &OpItemListResult{},
+			createItemErr:   fmt.Errorf("access denied"),
+		}
+		setupTest(t, m)
+
+		input := "protocol=https\nhost=github.com\nusername=alice\npassword=secret\n\n"
+		err := StoreCommand(strings.NewReader(input))
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "op item create failed") {
+			t.Errorf("error = %q, want to contain 'op item create failed'", err)
+		}
+	})
+
+	t.Run("no-op when credentials unchanged", func(t *testing.T) {
+		m := &mockRunner{
+			listItemsResult: &OpItemListResult{
+				{Id: "item-1", URLs: []struct {
+					Href string `json:"href,omitempty"`
+				}{{Href: "https://github.com"}}},
+			},
+			getItemResult: OpItem{
+				{Label: "username", Value: "alice"},
+				{Label: "password", Value: "secret"},
+			},
+		}
+		setupTest(t, m)
+
+		input := "protocol=https\nhost=github.com\nusername=alice\npassword=secret\n\n"
+		err := StoreCommand(strings.NewReader(input))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(m.editItemCalledWith) != 0 {
+			t.Errorf("EditItem called %d times, want 0", len(m.editItemCalledWith))
+		}
+	})
+
+	t.Run("edit when password changed", func(t *testing.T) {
+		m := &mockRunner{
+			listItemsResult: &OpItemListResult{
+				{Id: "item-1", URLs: []struct {
+					Href string `json:"href,omitempty"`
+				}{{Href: "https://github.com"}}},
+			},
+			getItemResult: OpItem{
+				{Label: "username", Value: "alice"},
+				{Label: "password", Value: "old-secret"},
+			},
+		}
+		setupTest(t, m)
+
+		input := "protocol=https\nhost=github.com\nusername=alice\npassword=new-secret\n\n"
+		err := StoreCommand(strings.NewReader(input))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(m.editItemCalledWith) != 1 {
+			t.Fatalf("EditItem called %d times, want 1", len(m.editItemCalledWith))
+		}
+		args := m.editItemCalledWith[0]
+		// First arg should be the item ID
+		if args[0] != "item-1" {
+			t.Errorf("EditItem first arg = %q, want 'item-1'", args[0])
+		}
+	})
+
+	t.Run("edit when username changed", func(t *testing.T) {
+		m := &mockRunner{
+			listItemsResult: &OpItemListResult{
+				{Id: "item-1", URLs: []struct {
+					Href string `json:"href,omitempty"`
+				}{{Href: "https://github.com"}}},
+			},
+			getItemResult: OpItem{
+				{Label: "username", Value: "alice"},
+				{Label: "password", Value: "secret"},
+			},
+		}
+		setupTest(t, m)
+
+		input := "protocol=https\nhost=github.com\nusername=bob\npassword=secret\n\n"
+		err := StoreCommand(strings.NewReader(input))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(m.editItemCalledWith) != 1 {
+			t.Fatalf("EditItem called %d times, want 1", len(m.editItemCalledWith))
+		}
+	})
+
+	t.Run("edit error", func(t *testing.T) {
+		m := &mockRunner{
+			listItemsResult: &OpItemListResult{
+				{Id: "item-1", URLs: []struct {
+					Href string `json:"href,omitempty"`
+				}{{Href: "https://github.com"}}},
+			},
+			getItemResult: OpItem{
+				{Label: "username", Value: "alice"},
+				{Label: "password", Value: "old"},
+			},
+			editItemErr: fmt.Errorf("network error"),
+		}
+		setupTest(t, m)
+
+		input := "protocol=https\nhost=github.com\nusername=alice\npassword=new\n\n"
+		err := StoreCommand(strings.NewReader(input))
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "op item edit failed") {
+			t.Errorf("error = %q, want to contain 'op item edit failed'", err)
+		}
+	})
+
+	t.Run("get item error during update", func(t *testing.T) {
+		m := &mockRunner{
+			listItemsResult: &OpItemListResult{
+				{Id: "item-1", URLs: []struct {
+					Href string `json:"href,omitempty"`
+				}{{Href: "https://github.com"}}},
+			},
+			getItemErr: fmt.Errorf("item corrupted"),
+		}
+		setupTest(t, m)
+
+		input := "protocol=https\nhost=github.com\nusername=alice\npassword=secret\n\n"
+		err := StoreCommand(strings.NewReader(input))
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "op item get failed") {
+			t.Errorf("error = %q, want to contain 'op item get failed'", err)
+		}
+	})
+
+	t.Run("list items error", func(t *testing.T) {
+		m := &mockRunner{
+			listItemsErr: fmt.Errorf("op not found"),
+		}
+		setupTest(t, m)
+
+		input := "protocol=https\nhost=github.com\nusername=alice\npassword=secret\n\n"
+		err := StoreCommand(strings.NewReader(input))
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("invalid input", func(t *testing.T) {
+		m := &mockRunner{}
+		setupTest(t, m)
+
+		input := "malformed\n"
+		err := StoreCommand(strings.NewReader(input))
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("with prefix in title", func(t *testing.T) {
+		m := &mockRunner{
+			listItemsResult: &OpItemListResult{},
+		}
+		setupTest(t, m)
+		Prefix = "git-"
+
+		input := "protocol=https\nhost=github.com\nusername=alice\npassword=secret\n\n"
+		err := StoreCommand(strings.NewReader(input))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		args := m.createItemCalledWith[0]
+		var titleFound bool
+		for _, arg := range args {
+			if arg == "--title=git-github.com" {
+				titleFound = true
+			}
+		}
+		if !titleFound {
+			t.Errorf("expected title 'git-github.com' in args: %v", args)
+		}
+	})
+
+	t.Run("with explicit ItemID skips create", func(t *testing.T) {
+		m := &mockRunner{
+			getItemResult: OpItem{
+				{Label: "username", Value: "alice"},
+				{Label: "password", Value: "old"},
+			},
+		}
+		setupTest(t, m)
+		ItemID = "explicit-id"
+
+		input := "protocol=https\nhost=github.com\nusername=alice\npassword=new\n\n"
+		err := StoreCommand(strings.NewReader(input))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// Should edit, not create
+		if len(m.createItemCalledWith) != 0 {
+			t.Errorf("CreateItem called %d times, want 0", len(m.createItemCalledWith))
+		}
+		if len(m.editItemCalledWith) != 1 {
+			t.Fatalf("EditItem called %d times, want 1", len(m.editItemCalledWith))
+		}
+	})
+}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -89,12 +90,19 @@ func main() {
 	// ref: https://git-scm.com/docs/gitcredentials
 	switch args[0] {
 	case "get":
-		internal.GetCommand()
+		if err := internal.GetCommand(os.Stdin, os.Stdout); err != nil {
+			if errors.Is(err, internal.ErrNotFound) {
+				os.Exit(1)
+			}
+			log.Fatalf("%s", err)
+		}
 	case "store":
 		if internal.ReadOnly {
 			return
 		}
-		internal.StoreCommand()
+		if err := internal.StoreCommand(os.Stdin); err != nil {
+			log.Fatalf("%s", err)
+		}
 	case "erase":
 		if internal.ReadOnly {
 			return
@@ -103,7 +111,9 @@ func main() {
 			flag.Usage()
 			log.Fatalf("To enable erasing credentials, use the -erase true flag")
 		}
-		internal.EraseCommand()
+		if err := internal.EraseCommand(os.Stdin); err != nil {
+			log.Fatalf("%s", err)
+		}
 	default:
 		// unknown argument
 		log.Fatalf("It doesn't look like anything to me. (Unknown argument: %s)\n", args[0])

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// buildBinary builds the test binary and returns its path.
+func buildBinary(t *testing.T) string {
+	t.Helper()
+	binary := filepath.Join(t.TempDir(), "git-credential-1password.exe")
+	cmd := exec.Command("go", "build", "-o", binary, ".")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("failed to build binary: %v\n%s", err, output)
+	}
+	return binary
+}
+
+func TestVersionFlag(t *testing.T) {
+	binary := buildBinary(t)
+	cmd := exec.Command(binary, "--version")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("unexpected error: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "git-credential-1password") {
+		t.Errorf("version output = %q, want to contain 'git-credential-1password'", output)
+	}
+}
+
+func TestNoArguments(t *testing.T) {
+	binary := buildBinary(t)
+	cmd := exec.Command(binary)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("expected ExitError, got %T", err)
+	}
+	if exitErr.ExitCode() != 2 {
+		t.Errorf("exit code = %d, want 2", exitErr.ExitCode())
+	}
+	if !strings.Contains(string(output), "usage:") {
+		t.Errorf("output = %q, want to contain 'usage:'", output)
+	}
+}
+
+func TestUnknownSubcommand(t *testing.T) {
+	binary := buildBinary(t)
+	cmd := exec.Command(binary, "unknown")
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(string(output), "Unknown argument") {
+		t.Errorf("output = %q, want to contain 'Unknown argument'", output)
+	}
+}
+
+func TestGetVersion(t *testing.T) {
+	got := getVersion()
+	if got == "" {
+		t.Error("getVersion() returned empty string")
+	}
+}
+
+func TestReadOnlyStoreIsNoop(t *testing.T) {
+	binary := buildBinary(t)
+	cmd := exec.Command(binary, "-read-only", "store")
+	cmd.Stdin = strings.NewReader("protocol=https\nhost=example.com\n\n")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("unexpected error: %v\n%s", err, output)
+	}
+}
+
+func TestReadOnlyEraseIsNoop(t *testing.T) {
+	binary := buildBinary(t)
+	cmd := exec.Command(binary, "-read-only", "erase")
+	cmd.Stdin = strings.NewReader("protocol=https\nhost=example.com\n\n")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("unexpected error: %v\n%s", err, output)
+	}
+}
+
+func TestEraseWithoutFlag(t *testing.T) {
+	binary := buildBinary(t)
+	cmd := exec.Command(binary, "erase")
+	cmd.Stdin = strings.NewReader("protocol=https\nhost=example.com\n\n")
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(string(output), "-erase true") {
+		t.Errorf("output = %q, want to contain '-erase true'", output)
+	}
+}
+
+func TestTooManyArguments(t *testing.T) {
+	binary := buildBinary(t)
+	cmd := exec.Command(binary, "get", "extra")
+	_, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("expected ExitError, got %T", err)
+	}
+	if exitErr.ExitCode() != 2 {
+		t.Errorf("exit code = %d, want 2", exitErr.ExitCode())
+	}
+}


### PR DESCRIPTION
- Refactored ReadLines function to accept an io.Reader and return a map of key-value pairs with error handling.
- Added unit tests for ReadLines to cover various input scenarios including valid, malformed, and edge cases.
- Introduced a mockRunner for testing the OpRunner interface, allowing for controlled testing of credential operations.
- Updated StoreCommand to use the new ReadLines signature and handle errors appropriately.
- Implemented tests for StoreCommand to validate creation and editing of credentials, including scenarios for unchanged credentials and error handling.
- Enhanced main command handling to support error propagation and logging for credential operations.
- Added integration tests for the main binary to validate command-line behavior and error handling.