### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: ["*"]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/ethrgeist/git-credential-1password/security/code-scanning/1](https://github.com/ethrgeist/git-credential-1password/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions` block for the workflow or for the specific job, granting only the minimal scopes needed. In this workflow, the steps only need to read the repository source code (`actions/checkout`) and then build and test locally; they do not create releases, push commits, or interact with issues or pull requests via the API. Therefore the minimal appropriate permissions are `contents: read`, and no `write` scopes appear to be required.

The best fix without changing existing functionality is to add a `permissions` section at the root level of the workflow (so it applies to all jobs, including `test`). Concretely, in `.github/workflows/test.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `jobs:` block (e.g., after line 5 and a blank line). This does not affect any step behavior, since they already operate within these limits, but it ensures the `GITHUB_TOKEN` cannot be used to write repository contents or perform other unintended actions. No additional imports, methods, or definitions are needed because this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
